### PR TITLE
18 reduce code complexity

### DIFF
--- a/src/project.py
+++ b/src/project.py
@@ -159,45 +159,37 @@ class Project:
         local_ids = self.get_local_ids()
         # Files to be downloaded.
         tbd_ids = [id_ for id_ in remote_ids if id_ not in local_ids]
-        # Some local PDB files are not in the RCSB database anymore, so we mark them with the SUFFIX_REMOVED suffix.
         print('Local IDs:', len(local_ids))
         print('Remote IDs:', len(remote_ids))
+
+        # Some local PDB files are not in the RCSB database anymore, so we mark them with the SUFFIX_REMOVED suffix.
         removed_ids = [id_ for id_ in local_ids if id_ not in remote_ids]
-        # Now we can calculate the number of files already downloaded.
-        n_downloaded_ok = len(local_ids) - len(removed_ids)
-
-        # Print a numeric report of:
-        # - the number of all remote PDB files (in the RCSB database) related to the queries;
-        # - the number of remote files already in the local project directory;
-        # - the number of PDB files that are in the remote database and not in the local project directory;
-        # - the number of removed/obsolete PDB files (i.e. those that are not in the remote database anymore).
-        if tbd_ids:
-            completion_rate = round(100 * n_downloaded_ok / len(remote_ids), 3)
-            print(f'{n_downloaded_ok}/{len(remote_ids)} ({completion_rate}%)')
-        else:
-            if self.verbose:
-                print(f'🦜 Up to date ({len(remote_ids):,} structures).')
-
-        if removed_ids:
-            # Print the list of removed/obsolete PDB files.
-            print('\n'.join(removed_ids))
-            print(f'🗑 Obsolete files (local but not remote): {len(removed_ids):,}')
 
         self.remote_pdb_ids = remote_ids
         self.tbd_pdb_ids = tbd_ids
         self.obsolete_pdb_ids = removed_ids
 
-        # return tbd_ids, removed_ids in a namedtuple
         return FetchResult(tbd_ids, removed_ids)
 
-    def mark_obsolete(self) -> None:
+    def handle_removed(self, fetch_result: FetchResult) -> None:
         """
         Mark obsolete the local PDB files that are not in the remote database anymore.
         """
+        # Fetch the remote RCSB IDs.
+        removed_ids = fetch_result.removed_ids
+
+        if not removed_ids:
+            return
+
+        # Print the list of removed/obsolete PDB files.
+        print('\n'.join(removed_ids))
+        print(f'🗑 Obsolete files (local but not remote): {len(removed_ids):,}')
+
         for id_ in self.obsolete_pdb_ids:
             pdb_file = os.path.join(self.data_dir, id_ + PDB_EXT)
             if os.path.isfile(pdb_file):
-                print('Marking obsolete:', pdb_file, '->', pdb_file + SUFFIX_REMOVED)
+                if self.verbose:
+                    print('Marking obsolete:', pdb_file, '->', pdb_file + SUFFIX_REMOVED)
                 os.rename(pdb_file, pdb_file + SUFFIX_REMOVED)
 
     def pull(self, n_jobs: int) -> None:
@@ -241,18 +233,14 @@ def main(project_dir: str, n_jobs: int = 1, verbose: bool = False) -> None:
     project = Project(project_dir, verbose=verbose)
 
     # Fetch the remote RCSB IDs.
-    tbd_ids, removed_ids = project.fetch()
+    fetch_result = project.fetch()
 
     # Mark obsolete the local PDB files that are not in the remote database anymore.
-    if (
-        removed_ids
-        and input(f'\nMark {len(removed_ids)} PDB files as obsolete? (y/n) ') == 'y'
-    ):
-        project.mark_obsolete()
+    project.handle_removed(fetch_result)
 
     # Ask the user to confirm the download of missing PDB files.
-    if len(tbd_ids) > 0:
-        answer = input(f'\nDo you want to download {len(tbd_ids)} PDB files? (y/n) ')
+    if len(fetch_result.tbd_ids) > 0:
+        answer = input(f'\nDo you want to download {len(fetch_result.tbd_ids)} PDB files? (y/n) ')
         if answer.lower() == 'y':
             project.pull(n_jobs=n_jobs)
         else:

--- a/src/project.py
+++ b/src/project.py
@@ -122,11 +122,8 @@ class Project:
         """
         print('Searching RCSB IDs...')
         remote_ids = []
-        for query_file in os.listdir(self.queries_dir):
-            if not query_file.endswith('.json'):
-                continue
-            query = os.path.join(self.queries_dir, query_file)
-            remote_ids += search_and_download_ids(query)
+        for query_file in (filename for filename in os.listdir(self.queries_dir) if filename.endswith('.json')):
+            remote_ids.extend(search_and_download_ids(os.path.join(self.queries_dir, query_file)))
 
         # Cache the ids.
         store_pdb_ids(remote_ids, cache_file)

--- a/src/project.py
+++ b/src/project.py
@@ -120,6 +120,7 @@ class Project:
         :param cache_file: path to the file where the list of RCSB IDs will be saved.
         :return: list of RCSB IDs.
         """
+        print('Searching RCSB IDs...')
         remote_ids = []
         for query_file in os.listdir(self.queries_dir):
             if not query_file.endswith('.json'):
@@ -146,13 +147,9 @@ class Project:
         ids_cache_file = self._get_cache_file()
         if os.path.isfile(ids_cache_file):
             # Read the ids from the _ids_<date>.txt file.
-            remote_ids = load_pdb_ids(ids_cache_file)
-        else:
-            # Get the list of PDB IDs from the RCSB website, given an advanced query in json format.
-            if self.verbose:
-                print('Fetching remote IDs...')
-            remote_ids = self.fetch_remote_ids(ids_cache_file)
-        return remote_ids
+            return load_pdb_ids(ids_cache_file)
+        # Get the list of PDB IDs from the RCSB website, given an advanced query in json format.
+        return self.fetch_remote_ids(ids_cache_file)
 
     def fetch(self) -> FetchResult:
         """

--- a/src/project.py
+++ b/src/project.py
@@ -107,11 +107,7 @@ class Project:
         """
         Get the PDB IDs that are already in the project directory.
         """
-        local_ids = set()
-        for filename in os.listdir(self.data_dir):
-            if filename.endswith('pdb.gz'):
-                local_ids.add(filename[:-7])
-        return local_ids
+        return {filename[:-7] for filename in os.listdir(self.data_dir) if filename.endswith('pdb.gz')}
 
     def fetch_remote_ids(self, cache_file: str) -> List[str]:
         """

--- a/src/project.py
+++ b/src/project.py
@@ -217,9 +217,7 @@ class Project:
 
         :param n_jobs: number of parallel jobs to download the PDB files.
         """
-        if not self.remote_pdb_ids:
-            # If the remote RCSB IDs have not been fetched yet, fetch them.
-            tbd_ids, _ = self.fetch()
+        tbd_ids, _ = self.fetch()
 
         # Download the PDB files corresponding to the RCSB PDB IDs which are not already in the project directory.
         total_tbd_ids = len(tbd_ids)

--- a/src/test_project.py
+++ b/src/test_project.py
@@ -1,6 +1,10 @@
 """
 Unit tests for the project module.
 """
+# Standard Library
+import os
+from pathlib import Path
+
 # 3rd party
 import pytest
 import responses
@@ -26,6 +30,21 @@ def empty_project(tmp_path):
     query_file1.write_text(HS_QUERY)
     query_file2.write_text(RN_QUERY)
     return Project(tmp_path)
+
+
+@pytest.fixture
+def project_with_files(empty_project):  # pylint: disable=redefined-outer-name
+    """Return a project with some downloaded files."""
+    # add pdb.gz files inside the project directory
+    hs01 = Path(empty_project.data_dir, 'hs01.pdb.gz')
+    hs02 = Path(empty_project.data_dir, 'hs02.pdb.gz')
+    rn01 = Path(empty_project.data_dir, 'rn01.pdb.gz')
+    rn02 = Path(empty_project.data_dir, 'rn02.pdb.gz')
+    hs01.write_text('hs01', encoding='ascii')
+    hs02.write_text('hs02', encoding='ascii')
+    rn01.write_text('rn01', encoding='ascii')
+    rn02.write_text('rn02', encoding='ascii')
+    return empty_project
 
 
 @pytest.fixture
@@ -101,3 +120,35 @@ def test_second_fetch_same_results(empty_project,  # pylint: disable=redefined-o
 
     # The second fetch should not call requests.get() (because the ids are loaded from the local cache).
     assert len(mocked_responses.calls) == 2
+
+
+def test_removed_handling(project_with_files, mocked_responses):  # pylint: disable=redefined-outer-name
+    """
+    Test that the remote-removed ids are handled properly.
+    """
+    mocked_responses.get(
+        url=f'{SEARCH_ENDPOINT_URI}',
+        body='{"result_set": [{"identifier": "hs01"}, {"identifier": "hs02"}]}',
+        status=200,
+        content_type="application/json",
+    )
+    # The remote server returns a different set of ids (rn02 is removed).
+    mocked_responses.get(
+        url=f'{SEARCH_ENDPOINT_URI}',
+        body='{"result_set": [{"identifier": "rn01"}]}',
+        status=200,
+        content_type="application/json",
+    )
+
+    fetch_result = project_with_files.fetch()
+    assert fetch_result.tbd_ids == []
+    assert fetch_result.removed_ids == ['rn02']
+
+    # The requests.get() method should be called two times, since there are two queries.
+    assert len(mocked_responses.calls) == 2
+
+    assert sorted(os.listdir(project_with_files.data_dir)) == [
+        'hs01.pdb.gz', 'hs02.pdb.gz', 'rn01.pdb.gz', 'rn02.pdb.gz']
+    project_with_files.handle_removed(fetch_result)
+    assert sorted(os.listdir(project_with_files.data_dir)) == [
+        'hs01.pdb.gz', 'hs02.pdb.gz', 'rn01.pdb.gz', 'rn02.pdb.gz.obsolete']


### PR DESCRIPTION
Like a cleanup before implementing the separated-directory feature, i.e. a separate directory for each query (#6).