### PR TITLE
40 follow up unused fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,10 +37,12 @@ def project_with_files(empty_project):
     # add pdb.gz files inside the project directory
     hs01 = Path(empty_project.data_dir, "hs01.pdb.gz")
     hs02 = Path(empty_project.data_dir, "hs02.pdb.gz")
+    hs03 = Path(empty_project.data_dir, "hs03.pdb.gz")
     rn01 = Path(empty_project.data_dir, "rn01.pdb.gz")
     rn02 = Path(empty_project.data_dir, "rn02.pdb.gz")
     hs01.write_text("hs01", encoding="ascii")
     hs02.write_text("hs02", encoding="ascii")
+    hs03.write_text("hs03", encoding="ascii")
     rn01.write_text("rn01", encoding="ascii")
     rn02.write_text("rn02", encoding="ascii")
     return empty_project

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,7 +77,7 @@ def mocked_responses():
 def remote_server(mocked_responses):
     """Return a mocked remote server with ids."""
     # Add responses to the mocked server for the queries.
-    mocked_responses.add(make_search_response(["hs01", "hs02"]))
+    mocked_responses.add(make_search_response(["hs01", "hs02", "hs03"]))
     # Second query.
     mocked_responses.add(make_search_response(["rn01", "rn02"]))
     return mocked_responses

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,3 @@
+"""
+Test of download functions.
+"""

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -24,7 +24,7 @@ def test_updiff_the_first_time(empty_project, remote_server):
     Test that the first time the project check for updates, all the remote ids are considered to be downloaded.
     """
     tbd_ids, removed_ids = empty_project.updiff()
-    assert set(tbd_ids) == {"hs01", "hs02", "rn01", "rn02"}
+    assert set(tbd_ids) == {"hs01", "hs02", "hs03", "rn01", "rn02"}
     assert removed_ids == []
 
 
@@ -38,7 +38,7 @@ def test_second_updiff_same_results(empty_project, remote_server):
     """
     # First updiff.
     tbd_ids, removed_ids = empty_project.updiff()
-    assert set(tbd_ids) == {"hs01", "hs02", "rn01", "rn02"}
+    assert set(tbd_ids) == {"hs01", "hs02", "hs03", "rn01", "rn02"}
     assert removed_ids == []
 
     # The requests.get() method should be called two times, since there are two queries.
@@ -46,7 +46,7 @@ def test_second_updiff_same_results(empty_project, remote_server):
 
     # Second updiff.
     tbd_ids, removed_ids = empty_project.updiff()
-    assert set(tbd_ids) == {"hs01", "hs02", "rn01", "rn02"}
+    assert set(tbd_ids) == {"hs01", "hs02", "hs03", "rn01", "rn02"}
     assert removed_ids == []
 
     # The second updiff should not call requests.get() (because the ids are loaded from the local cache).


### PR DESCRIPTION
- [ ] Use an unused fixture (and DRY), and solve #40 
- [ ] in tests, "hs" has now 3 files, "rn" 2 (just to have a difference in terms of number of data files)
