### PR TITLE
72 improve download logging

### DIFF
--- a/src/download.py
+++ b/src/download.py
@@ -269,10 +269,10 @@ def download(
             # Log the same but using %s instead of f-strings, to avoid formatting the string
             # if the log level is higher than INFO.
             if pdb_res.status_code == 200:
-                logging.info("PDB file downloaded: id='%s', url='%s'", pdb_res.pdb_id, pdb_res.pdb_url)
+                logging.debug("PDB file downloaded: id='%s', url='%s'", pdb_res.pdb_id, pdb_res.pdb_url)
             else:
-                logging.info(
-                    "PDB file NOT FOUND: id='%s', url='%s'",
+                logging.debug(
+                    "PDB file NOT FOUND : id='%s', url='%s'",
                     pdb_res.pdb_id,
                     pdb_res.pdb_url,
                 )

--- a/src/download.py
+++ b/src/download.py
@@ -242,6 +242,7 @@ def download(
     n_ids = len(pdb_ids)
     downloaded_size = 0
     n_downloaded = 0
+    n_not_found = 0
     start_time = time.time()
 
     chunk_len = CHUNK_LEN_PER_PROCESS * n_jobs
@@ -276,6 +277,7 @@ def download(
                     pdb_res.pdb_id,
                     pdb_res.pdb_url,
                 )
+                n_not_found += 1
 
         downloaded_size += sum(
             os.path.getsize(file_path) for _, _, file_path, _ in downloaded_chunk
@@ -289,8 +291,10 @@ def download(
     t_sec = time.time() - start_time
     speed = n_downloaded / t_sec
     logging.info(
-        "Downloaded %s PDB files in %s (%.2f/s)",
-        n_downloaded,
+        "Downloaded %s PDB files (%.3f GB), %d not found, in %s (%.2f/s) in this session",
+        n_downloaded - n_not_found,
+        downloaded_size / 1e9,
+        n_not_found,
         _human_readable_time(t_sec),
         speed,
     )

--- a/src/download.py
+++ b/src/download.py
@@ -32,7 +32,9 @@ DEFAULT_PROCESSES = 1
 #: This is scaled automatically to the number of processes used to keep the progress updates constant.
 CHUNK_LEN_PER_PROCESS = 20
 
-PDBDownloadResult = namedtuple("PDBDownloadResult", ["pdb_id", "pdb_url", "local_path", "status_code"])
+PDBDownloadResult = namedtuple(
+    "PDBDownloadResult", ["pdb_id", "pdb_url", "local_path", "status_code"]
+)
 
 
 def _chunks(lst, num):
@@ -118,7 +120,9 @@ def get_download_url(pdb_id: str) -> str:
     return f"{DOWNLOAD_URL_RCSB}{pdb_id}.pdb"
 
 
-def download_pdb(pdb_id: str, directory: str, compressed: bool = True) -> PDBDownloadResult:
+def download_pdb(
+    pdb_id: str, directory: str, compressed: bool = True
+) -> PDBDownloadResult:
     """
     Download a PDB file from the RCSB website.
 
@@ -161,7 +165,12 @@ def download_pdb(pdb_id: str, directory: str, compressed: bool = True) -> PDBDow
     # Save the PDB file.
     with open(dest, "wb") as file_pointer:
         file_pointer.write(content)
-    return PDBDownloadResult(pdb_id=pdb_id, pdb_url=pdb_url, local_path=dest, status_code=response.status_code)
+    return PDBDownloadResult(
+        pdb_id=pdb_id,
+        pdb_url=pdb_url,
+        local_path=dest,
+        status_code=response.status_code,
+    )
 
 
 # Use multiprocessing to download (typically thousands of) PDB files in parallel.
@@ -270,7 +279,11 @@ def download(
             # Log the same but using %s instead of f-strings, to avoid formatting the string
             # if the log level is higher than INFO.
             if pdb_res.status_code == 200:
-                logging.debug("PDB file downloaded: id='%s', url='%s'", pdb_res.pdb_id, pdb_res.pdb_url)
+                logging.debug(
+                    "PDB file downloaded: id='%s', url='%s'",
+                    pdb_res.pdb_id,
+                    pdb_res.pdb_url,
+                )
             else:
                 logging.debug(
                     "PDB file NOT FOUND : id='%s', url='%s'",
@@ -289,12 +302,11 @@ def download(
 
     # Log the number of downloaded PDB files, the total time and the average speed.
     t_sec = time.time() - start_time
-    speed = n_downloaded / t_sec
     logging.info(
         "Downloaded %s PDB files (%.3f GB), %d not found, in %s (%.2f/s) in this session",
         n_downloaded - n_not_found,
         downloaded_size / 1e9,
         n_not_found,
         _human_readable_time(t_sec),
-        speed,
+        n_downloaded / t_sec,
     )

--- a/src/download.py
+++ b/src/download.py
@@ -9,6 +9,7 @@ of a given project, to keep the local working directory up-to-date).
 import logging
 import os
 import time
+from collections import namedtuple
 from functools import partial
 from multiprocessing import Pool
 from typing import List
@@ -30,6 +31,8 @@ DEFAULT_PROCESSES = 1
 #: It is the number of PDB files to download before a progress update is printed if a single process is used.
 #: This is scaled automatically to the number of processes used to keep the progress updates constant.
 CHUNK_LEN_PER_PROCESS = 20
+
+PDBDownloadResult = namedtuple("PDBDownloadResult", ["pdb_id", "pdb_url", "local_path", "status_code"])
 
 
 def _chunks(lst, num):
@@ -115,7 +118,7 @@ def get_download_url(pdb_id: str) -> str:
     return f"{DOWNLOAD_URL_RCSB}{pdb_id}.pdb"
 
 
-def download_pdb(pdb_id: str, directory: str, compressed: bool = True) -> str:
+def download_pdb(pdb_id: str, directory: str, compressed: bool = True) -> PDBDownloadResult:
     """
     Download a PDB file from the RCSB website.
 
@@ -158,7 +161,7 @@ def download_pdb(pdb_id: str, directory: str, compressed: bool = True) -> str:
     # Save the PDB file.
     with open(dest, "wb") as file_pointer:
         file_pointer.write(content)
-    return dest
+    return PDBDownloadResult(pdb_id=pdb_id, pdb_url=pdb_url, local_path=dest, status_code=response.status_code)
 
 
 # Use multiprocessing to download (typically thousands of) PDB files in parallel.
@@ -167,7 +170,7 @@ def parallel_download(
     directory: str,
     compressed: bool = True,
     n_jobs: int = DEFAULT_PROCESSES,
-) -> List[str]:
+) -> List[PDBDownloadResult]:
     """
     Download PDB files from the RCSB website in parallel.
 
@@ -182,7 +185,7 @@ def parallel_download(
             partial(download_pdb, directory=directory, compressed=compressed), pdb_ids
         )
         # remove null values
-        return [x for x in ret if x != ""]
+        return [pdb_res for pdb_res in ret if pdb_res.local_path != ""]
 
 
 def download(
@@ -260,15 +263,22 @@ def download(
     for chunk in _chunks(pdb_ids, chunk_len):
         downloaded_chunk = parallel_download(chunk, directory, compressed, n_jobs)
 
-        # Log the downloaded PDB files
-        for pdb_file in downloaded_chunk:
-            if os.path.getsize(pdb_file) > 0:
-                logging.info("Downloaded: %s", pdb_file)
-            else:  # pragma: no cover (difficult to test with real queries, we need to mock the response)
-                logging.info("Empty size: %s", pdb_file)
+        # Log the downloaded PDB files.
+        for pdb_res in downloaded_chunk:
+            # logging.info(f"PDB file downloaded, id='{pdb_id}', url='{pdb_url}'")
+            # Log the same but using %s instead of f-strings, to avoid formatting the string
+            # if the log level is higher than INFO.
+            if pdb_res.status_code == 200:
+                logging.info("PDB file downloaded: id='%s', url='%s'", pdb_res.pdb_id, pdb_res.pdb_url)
+            else:
+                logging.info(
+                    "PDB file NOT FOUND: id='%s', url='%s'",
+                    pdb_res.pdb_id,
+                    pdb_res.pdb_url,
+                )
 
         downloaded_size += sum(
-            os.path.getsize(file_path) for file_path in downloaded_chunk
+            os.path.getsize(file_path) for _, _, file_path, _ in downloaded_chunk
         )
         n_downloaded += len(chunk)
 

--- a/src/project.py
+++ b/src/project.py
@@ -342,7 +342,7 @@ def main(
         logging.debug("Nothing to do.")
         return
 
-    logging.info("📥 Total new files to be downloaded: %d", total_tbd_ids)
+    logging.info("📥 Number of new pdb files to download overall: %7d", total_tbd_ids)
 
     # If "--noop" argument is given, exit.
     if noop:

--- a/src/project.py
+++ b/src/project.py
@@ -219,7 +219,7 @@ class Project:
         # Remote structures to be downloaded.
         tbd_ids = [id_ for id_ in remote_ids if id_ not in local_ids]
         logging.info(
-            "%s: %7d local, %7d remote, %7d to download",
+            "%-25s: %7d local, %7d remote, %7d to download",
             query_name,
             n_local,
             n_remote,

--- a/src/project.py
+++ b/src/project.py
@@ -128,6 +128,35 @@ def pformat_status(project_status: ProjectStatus) -> str:
     ).replace(",", " ")
 
 
+def log_dir_status(dir_status: DirStatus, query_name: str):
+    """
+    Log the status of a directory.
+
+    :param dir_status: the status of the directory.
+    :param query_name: name of the query.
+    """
+    logging.debug(
+        "📁 %s: %d local, %d remote, %d to be downloaded, %d removed",
+        query_name,
+        dir_status.n_local,
+        dir_status.n_remote,
+        len(dir_status.tbd_ids),
+        len(dir_status.removed_ids),
+    )
+    if dir_status.tbd_ids:
+        logging.info(
+            "📥 %7d new files to be downloaded for query %s", len(dir_status.tbd_ids), query_name
+        )
+    if dir_status.removed_ids:
+        logging.info(
+            "🗑️ %d local PDB not returned by RCSB for query %s",
+            len(dir_status.removed_ids),
+            query_name,
+        )
+        for id_ in dir_status.removed_ids:
+            logging.info("old_id='%s', query='%s'", id_, query_name)
+
+
 class Project:
     """
     Keep synced the data directory with the remote RCSB database.
@@ -206,9 +235,6 @@ class Project:
         query_name = os.path.splitext(os.path.basename(query_path))[0]
         # Get the list of PDB IDs from the RCSB website.
         remote_ids = self.fetch_or_cache_query(query_path)
-        # logging.debug(f"{query_name:<30}: {len(remote_ids):>7,} remote IDs.")
-        # Log the same but using %s to avoid the formatting if the log level is not DEBUG.
-        logging.debug("%s: %7d remote IDs", query_name, len(remote_ids))
         # Check which PDB files are already in the local project directory, and skip those to save time.
         local_ids = self.scan_query_data(query_name)
         n_local = len(local_ids)
@@ -218,31 +244,10 @@ class Project:
 
         # Remote structures to be downloaded.
         tbd_ids = [id_ for id_ in remote_ids if id_ not in local_ids]
-        logging.info(
-            "%-25s: %7d local, %7d remote, %7d to download",
-            query_name,
-            n_local,
-            n_remote,
-            len(tbd_ids),
-        )
+
         # Local files to be removed (some local PDB files are not in the RCSB database anymore,
         # so we mark them with the SUFFIX_REMOVED suffix).
         removed_ids = [id_ for id_ in local_ids if id_ not in remote_ids]
-
-        # Report the removed files.
-        if removed_ids:
-            # logging.info(
-            #     f"Locally found {len(removed_ids):,} files not returned by RCSB for {query_name}.")
-            logging.info(
-                "Locally found %d files not returned by RCSB for %s",
-                len(removed_ids),
-                query_name,
-            )
-            for id_ in removed_ids:
-                # logging.info(f"old_id='{id_}', query='{query_name}'")
-                # log the same but using %s to avoid the formatting if the log level is not INFO.
-                logging.info("old_id='%s', query='%s'", id_, query_name)
-
         return DirStatus(n_local, n_remote, tbd_ids, removed_ids, zero_ids)
 
     def get_status(self) -> ProjectStatus:
@@ -255,11 +260,12 @@ class Project:
         for query_file in (
             filename
             for filename in sorted(os.listdir(self.queries_dir))
-            if filename.endswith(".json")
+            if filename.endswith(".json") and not filename.startswith(".")
         ):
             name = os.path.splitext(query_file)[0]
             query_path = os.path.join(self.queries_dir, query_file)
             ret[name] = self.get_status_query(query_path)
+            log_dir_status(ret[name], name)
         return ret
 
     def mark_removed(self, query_name: str, to_remove: List[str]) -> None:
@@ -290,7 +296,7 @@ class Project:
         :param project_status: a dictionary mapping query names to DirStatus objects.
         :param n_jobs: number of parallel jobs to download the PDB files.
         """
-        logging.info("Starting synchronization.")
+        logging.debug("Starting synchronization.")
         for query_name, dir_status in project_status.items():
             self.mark_removed(query_name, dir_status.removed_ids)
             query_data_dir = os.path.join(self.data_dir, query_name)
@@ -310,7 +316,7 @@ def main(
     :param yes: if True, do not ask for confirmation before downloading the PDB files.
     """
     project = Project(project_dir)
-    logging.info("Project directory: %s", project_dir)
+    logging.debug("Project directory: %s", project_dir)
 
     # Fetch the remote RCSB IDs.
     project_status = project.get_status()
@@ -319,18 +325,21 @@ def main(
     print(project_dir)
     print(f"Date: {str(datetime.date.today())}")
     print(pformat_status(project_status))
-    print()
 
     # Count the total number of files to be downloaded.
     total_tbd_ids = sum(
         len(dir_status.tbd_ids) for dir_status in project_status.values()
     )
+    if total_tbd_ids == 0:
+        logging.debug("Nothing to do.")
+        return
+
     logging.info("📥 Total new files to be downloaded: %d", total_tbd_ids)
 
     # Download the PDB files corresponding to the RCSB PDB IDs which are not already in the project directory.
     if total_tbd_ids:
         if not yes:
-            answer = input("Do you want to download the PDB files? [y/N] ")
+            answer = input(f"\nDo you want to download the {total_tbd_ids} PDB files? [y/N] ")
             if answer.lower() != "y":
                 logging.info("User chose not to download the PDB files.")
                 return
@@ -386,7 +395,7 @@ if __name__ == "__main__":
     # Verbosity level for the logger (0: INFO, 1: DEBUG).
     console.setLevel(logging.DEBUG if args.verbose else logging.INFO)
 
-    logging.info("Starting script: %s", __file__)
+    logging.debug("Starting script: %s", __file__)
     # Log the command line arguments.
     logging.debug("Command line arguments: %s", args)
     main(args.project_dir, args.n_jobs, args.yes, args.compressed)

--- a/src/project.py
+++ b/src/project.py
@@ -80,7 +80,7 @@ DirStatus = namedtuple(
 ProjectStatus = Dict[str, DirStatus]
 
 
-def pformat_status(project_status: ProjectStatus) -> str:
+def pformat_status(project_status: ProjectStatus) -> str:  # pragma: no cover
     """
     Create a nice string table with the status of the project.
 
@@ -313,7 +313,8 @@ def main(
     yes: bool = False,
     noop: bool = False,
     compressed: bool = False,
-):
+    summary: bool = False,
+):  # pylint: disable=too-many-arguments
     """
     Fetch the RCSB IDs from the RCSB website, and download the corresponding PDB files.
 
@@ -330,9 +331,10 @@ def main(
     project_status = project.get_status()
 
     # Print the status of the project.
-    print(project_dir)
-    print(f"Date: {str(datetime.date.today())}")
-    print(pformat_status(project_status))
+    if summary:  # pragma: no cover
+        print(project_dir)
+        print(f"Date: {str(datetime.date.today())}")
+        print(pformat_status(project_status))
 
     # Count the total number of files to be downloaded.
     total_tbd_ids = sum(
@@ -392,6 +394,11 @@ if __name__ == "__main__":
         action="store_true",
         help="download compressed PDB files (not available for AlphaFold DB)",
     )
+    # Add an option to print the database summary table
+    parser.add_argument(
+        "-s", "--summary", action="store_true", help="print the database summary table"
+    )
+
     parser.add_argument("-v", "--verbose", action="store_true", help="verbose mode")
     args = parser.parse_args()
 
@@ -419,4 +426,11 @@ if __name__ == "__main__":
     logging.debug("Starting script: %s", __file__)
     # Log the command line arguments.
     logging.debug("Command line arguments: %s", args)
-    main(args.project_dir, args.n_jobs, args.yes, args.noop, args.compressed)
+    main(
+        args.project_dir,
+        args.n_jobs,
+        args.yes,
+        args.noop,
+        args.compressed,
+        args.summary,
+    )

--- a/src/project.py
+++ b/src/project.py
@@ -145,15 +145,15 @@ def log_dir_status(dir_status: DirStatus, query_name: str):
     )
     if dir_status.tbd_ids:
         logging.info(
-            "📥 %7d new files to be downloaded for query %s",
-            len(dir_status.tbd_ids),
+            "📥 %-30s:   new files: %7d",
             query_name,
+            len(dir_status.tbd_ids),
         )
     if dir_status.removed_ids:
         logging.info(
-            "🗑️ %d local PDB not returned by RCSB for query %s",
-            len(dir_status.removed_ids),
+            "🗑️ %-30s: local PDB not returned by RCSB: %7d",
             query_name,
+            len(dir_status.removed_ids),
         )
         for id_ in dir_status.removed_ids:
             logging.info("old_id='%s', query='%s'", id_, query_name)

--- a/tests/manualtest-prj-c-elegans/queries/c-elegans.json
+++ b/tests/manualtest-prj-c-elegans/queries/c-elegans.json
@@ -1,0 +1,30 @@
+{
+  "query": {
+    "type": "terminal",
+    "service": "text",
+    "parameters": {
+      "attribute": "rcsb_entity_source_organism.taxonomy_lineage.name",
+      "operator": "contains_phrase",
+      "negation": false,
+      "value": "Caenorhabditis elegans"
+    },
+    "label": "text"
+  },
+  "return_type": "entry",
+  "request_options": {
+    "paginate": {
+      "start": 0,
+      "rows": 999999
+    },
+    "results_content_type": [
+      "experimental"
+    ],
+    "sort": [
+      {
+        "sort_by": "score",
+        "direction": "desc"
+      }
+    ],
+    "scoring_strategy": "combined"
+  }
+}

--- a/tests/manualtest-prj-major_vault_protein/queries/major_vault_protein.json
+++ b/tests/manualtest-prj-major_vault_protein/queries/major_vault_protein.json
@@ -1,0 +1,29 @@
+{
+    "query": {
+      "type": "terminal",
+      "label": "text",
+      "service": "text",
+      "parameters": {
+        "attribute": "rcsb_uniprot_protein.name.value",
+        "operator": "contains_phrase",
+        "value": "Major vault protein"
+      }
+    },
+    "return_type": "entry",
+    "request_options": {
+      "paginate": {
+        "start": 0,
+        "rows": 999999
+      },
+      "results_content_type": [
+        "experimental"
+      ],
+      "sort": [
+        {
+          "sort_by": "score",
+          "direction": "desc"
+        }
+      ],
+      "scoring_strategy": "combined"
+    }
+  }

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -29,7 +29,7 @@ def datafile(filename: str) -> str:
 
 
 @pytest.mark.webtest
-def test_download_404(tmp_path):
+def test_download_pdb_404(tmp_path):
     """Test that if a pdb is not found, no exception is raised, but
     the downloaded file is empty. Then, check that the 404.txt list
     is updated.
@@ -128,3 +128,20 @@ def test_download_real_pdb_compressed():
     ), "Ops.. your fault? Compressed size bigger than uncompressed"
     assert dest.endswith(".gz")
     os.remove(dest)
+
+
+@pytest.mark.webtest
+def test_function_download__404(tmp_path):
+    """
+    Add coverage for the download function when the pdb is not found.
+    This PDB ids are real, but only one has a PDB file available for download.
+    """
+    datadir = tmp_path / "data"
+    datadir.mkdir()
+    ids = ["6BP8", "7PKR", "7PKY"]
+    download.download(ids, datadir, compressed=False)
+
+    # Test that only 6BP8.pdb is found.
+    assert os.path.getsize(datadir / "6BP8.pdb") > 0
+    assert os.path.getsize(datadir / "7PKR.pdb") == 0
+    assert os.path.getsize(datadir / "7PKY.pdb") == 0

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -84,8 +84,8 @@ def test_download_real_alphafold_pdb():
     res = download.download_pdb(pdb_id, directory=".", compressed=False)
     assert res == download.PDBDownloadResult(
         pdb_id=pdb_id,
-        pdb_url=f"https://alphafold.ebi.ac.uk/files/AF-P01308-F1-model_v4.pdb",
-        local_path=f"./AF-P01308-F1-model_v4.pdb",
+        pdb_url="https://alphafold.ebi.ac.uk/files/AF-P01308-F1-model_v4.pdb",
+        local_path="./AF-P01308-F1-model_v4.pdb",
         status_code=200,
     )
     dest = res.local_path

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -41,9 +41,15 @@ def test_download_404(tmp_path):
     txt404.write_text("fake\n", encoding="ascii")
 
     # Download a pdb that does not exist.
-    dest = download.download_pdb("0000", datadir)
+    res = download.download_pdb("0000", datadir, compressed=True)
+    assert res == download.PDBDownloadResult(
+        pdb_id="0000",
+        pdb_url="https://files.rcsb.org/download/0000.pdb.gz",
+        local_path=str(datadir / "0000.pdb.gz"),
+        status_code=404,
+    )
     # Check that the downloaded file is empty.
-    assert os.path.getsize(dest) == 0
+    assert os.path.getsize(res.local_path) == 0
     # Check that the 404.txt file is updated.
     with open(txt404, encoding="ascii") as file_pointer:
         assert file_pointer.read() == "fake\n0000\n"
@@ -55,12 +61,18 @@ def test_download_real_pdb():
     Test the download_pdb function.
     """
     pdb_id = HUMAN_INSULIN
-    dest = download.download_pdb(pdb_id, directory=".", compressed=False)
-    assert os.path.exists(dest)
+    res = download.download_pdb(pdb_id, directory=".", compressed=False)
+    assert res == download.PDBDownloadResult(
+        pdb_id=pdb_id,
+        pdb_url=f"https://files.rcsb.org/download/{pdb_id}.pdb",
+        local_path=f"./{pdb_id}.pdb",
+        status_code=200,
+    )
+    assert os.path.exists(res.local_path)
     assert (
-        os.path.getsize(dest) == HUMAN_INSULIN_SIZE
+        os.path.getsize(res.local_path) == HUMAN_INSULIN_SIZE
     ), "Wrong size for the downloaded file (?!)"
-    os.remove(dest)
+    os.remove(res.local_path)
 
 
 @pytest.mark.webtest
@@ -69,7 +81,14 @@ def test_download_real_alphafold_pdb():
     Test the download_pdb function.
     """
     pdb_id = HUMAN_INSULIN_ALPHAFOLD
-    dest = download.download_pdb(pdb_id, directory=".", compressed=False)
+    res = download.download_pdb(pdb_id, directory=".", compressed=False)
+    assert res == download.PDBDownloadResult(
+        pdb_id=pdb_id,
+        pdb_url=f"https://alphafold.ebi.ac.uk/files/AF-P01308-F1-model_v4.pdb",
+        local_path=f"./AF-P01308-F1-model_v4.pdb",
+        status_code=200,
+    )
+    dest = res.local_path
     assert os.path.exists(dest)
     assert (
         os.path.getsize(dest) == HUMAN_INSULIN_ALPHAFOLD_SIZE
@@ -92,7 +111,14 @@ def test_download_real_pdb_compressed():
     Test the download_pdb function with compressed files.
     """
     pdb_id = HUMAN_INSULIN
-    dest = download.download_pdb(pdb_id, directory=".", compressed=True)
+    res = download.download_pdb(pdb_id, directory=".", compressed=True)
+    assert res == download.PDBDownloadResult(
+        pdb_id=pdb_id,
+        pdb_url=f"https://files.rcsb.org/download/{pdb_id}.pdb.gz",
+        local_path=f"./{pdb_id}.pdb.gz",
+        status_code=200,
+    )
+    dest = res.local_path
     assert os.path.exists(dest)
     assert (
         os.path.getsize(dest) == HUMAN_INSULIN_SIZE_COMPRESSED

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -147,6 +147,31 @@ def test_project_no_updates(project_w_data_cleanup):
     check_data(project_dir)
 
 
+def test_project_noop(project_nodata_cleanup):
+    """
+    Test the option --noop.
+
+    There are files to download (not tested here),
+    but the --noop option should prevent the download.
+    """
+    project_dir = project_nodata_cleanup
+
+    # launch main with --noop
+    with patch("project.Project.do_sync") as mock_sync:
+        project.main(project_dir, noop=True)
+
+    # check that the sync function was *not* called (no download)
+    mock_sync.assert_not_called()
+
+    # Check that the data subdirectories are empty
+    data_dir = os.path.join(project_dir, "data")
+    assert sorted(os.listdir(data_dir)) == ["Rabbitpox_virus", "Radianthus_crispus"]
+    assert sorted(os.listdir(os.path.join(data_dir, "Rabbitpox_virus"))) == []
+    assert sorted(os.listdir(os.path.join(data_dir, "Radianthus_crispus"))) == []
+
+    # cleanup of downloaded files and cache (done by the fixture)
+
+
 # User input
 
 


### PR DESCRIPTION
See #72 

- log not-found PDB files (PDB id which are not found in the RCSB database)
- the logging is now more quiet (INFO -> DEBUG). If no update: no output.
- add option `-s/--summary` to display the table (default = False)
- add option `--noop` to avoid to download new files if found. Just report news if found.